### PR TITLE
Support other platforms besides linux when building jni.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ make -j8
 popd
 popd
 
-scripts/build-jni.sh
+lein clean && lein jni build-jni-java && lein jni build-and-install-jni
 ```
 
 

--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,10 @@
 
   :java-source-paths ["java"]
   :native-path "java/native/"
+  :tvm-clj-runtime-path "java/tvm_clj/tvm/runtime.java"
+  :jni-path "java/native"
+  :clean-targets
+  ^{:protect false} [:target-path :compile-path :jni-path :tvm-clj-runtime-path]
   :aot [tvm-clj.jni]
   :test-selectors {:default (complement :cuda)
                    :cuda :cuda}

--- a/src/tvm_clj/jni.clj
+++ b/src/tvm_clj/jni.clj
@@ -1,6 +1,25 @@
 (ns tvm-clj.jni
   (:gen-class)
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string])
   (:import [org.bytedeco.javacpp.tools Builder]))
+
+
+(defn lib-filename [libname] (System/mapLibraryName libname))
+
+
+(defn filepath [& parts] (string/join (java.io.File/separator) parts))
+
+
+(defn relpath
+  [& parts]
+  (apply filepath (System/getProperty "user.dir") parts))
+
+
+(defn native-path []
+  (relpath "java" "native"
+           (string/lower-case (string/replace (System/getProperty "os.name") #"\s+" ""))
+           (System/getProperty "os.arch")))
 
 
 (defn build-java-stub
@@ -10,22 +29,36 @@
 
 (defn build-jni-lib
   []
-  (Builder/main (into-array String ["tvm_clj.tvm.runtime" "-d"
-                                    (str (System/getProperty "user.dir")
-                                         "/java/native/linux/x86_64")
+  (Builder/main (into-array String ["tvm_clj.tvm.runtime" "-d" (native-path)
                                     "-nodelete" ;;When shit doesn't work this is very helpful
                                     "-Xcompiler"
-                                    (str "-I" (System/getProperty "user.dir") "/tvm/include/tvm")
+                                    (str "-I" (relpath "tvm" "include" "tvm"))
                                     "-Xcompiler"
-                                    (str "-I" (System/getProperty "user.dir") "/tvm/3rdparty/dlpack/include")
+                                    (str "-I" (relpath "tvm" "3rdparty" "dlpack" "include"))
                                     "-Xcompiler"
                                     "-std=c++11"
-                                    "-Xcompiler"
-                                    (str "-Wl," "--no-as-needed")
+                                    ;; This option breaks on OSX/Xcode/clang
+                                    ;;"-Xcompiler"
+                                    ;;(str "-Wl," "--no-as-needed")
                                     "-Xcompiler"
                                     (str "-Wl," "-ltvm_topi")
                                     "-Xcompiler"
-                                    (str "-L" (System/getProperty "user.dir") "/tvm/lib")])))
+                                    (str "-L" (relpath "tvm" "build"))])))
+
+
+(defn install-jni-lib
+  []
+  (.mkdirs (io/file (native-path)))
+  (doall (map #(io/copy (io/file (relpath "tvm" "build" (lib-filename %)))
+                        (io/file (filepath (native-path) (lib-filename %))))
+              ["tvm" "tvm_topi"])))
+
+
+
+(defn build-and-install-jni-lib
+  []
+  (build-jni-lib)
+  (install-jni-lib))
 
 
 (defn -main
@@ -38,4 +71,8 @@
       :build-jni-java ;;step 1
       (build-java-stub)
       :build-jni
-      (build-jni-lib))))
+      (build-jni-lib)
+      :install-jni
+      (install-jni-lib)
+      :build-and-install-jni
+      (build-and-install-jni-lib))))


### PR DESCRIPTION
Hello!

This looks like a really interesting project. This is my take on issues #4 and #3. I'm hoping this would also work on other platforms.

Note that on my system (OSX sierra / Apple LLVM version 8.1.0 (clang-802.0.42)), I needed to get rid of the "--no-as-needed" flag. 

Cheers,
Joel