### PR TITLE
Upgrade dtype 2.0

### DIFF
--- a/docs/free-errors.txt
+++ b/docs/free-errors.txt
@@ -1,0 +1,63 @@
+:tech.gc-resource Reference thread starting
+
+lein test tech.compute.tvm.tensor-test
+Library tvm found at [:system "/home/chrisn/dev/tvm-clj/tvm/build/libtvm.so"]
+allocated tensor of shape [18] : 140036096288064
+Library c found at [:system "c"]
+allocated tensor of shape [6] : 140036096278464
+deriving from root of shape [18] : 140036096288064
+before-gc
+after-gc
+allocated tensor of shape [2 3 6] : 140036085045632
+allocated tensor of shape [36] : 140036093667840
+copying
+copy finished
+host-copy-finished
+freeing root tensor of shape [36] : 140036093667840
+freeing root tensor of shape [2 3 6] : 140036085045632
+allocated tensor of shape [5] : 140036096457344
+deriving from root of shape [18] : 140036096288064
+new-tensor
+allocated tensor of shape [15] : 140036096449408
+before-gc-2
+freeing root tensor of shape [18] : 140036096288064
+freeing root tensor of shape [6] : 140036096278464
+freeing derived tensor of address: 140036096288064
+after-gc-2
+to-double-start
+allocated tensor of shape [15] : 140036071269952
+copying
+copy finished
+host-copy-finished
+freeing root tensor of shape [15] : 140036071269952
+
+lein test :only tech.compute.tvm.tensor-test/indexed-tensor-int64
+
+FAIL in (indexed-tensor-int64) (tensor.clj:620)
+Center loss use case
+expected: (m/equals [0 1 2 3 4 5 0 1 2 6 7 8 3 4 5] (vec (ct/to-double-array batch-data)))
+  actual: (not (m/equals [0 1 2 3 4 5 0 1 2 6 7 8 3 4 5] [1.40036093652544E14 1.0 2.0 3.0 4.0 5.0 1.40036093652544E14 1.0 2.0 6.0 7.0 8.0 3.0 4.0 5.0]))
+  to-double-end
+  to-double-start
+  allocated tensor of shape [5 3] : 140036097440448
+  allocated tensor of shape [15] : 140036097469504
+  copying
+  freeing root tensor of shape [15] : 140036096449408
+  copy finished
+  host-copy-finished
+  freeing root tensor of shape [15] : 140036097469504
+  freeing root tensor of shape [5 3] : 140036097440448
+
+lein test :only tech.compute.tvm.tensor-test/indexed-tensor-int64
+
+FAIL in (indexed-tensor-int64) (tensor.clj:628)
+Center loss use case
+expected: (m/equals [0 3 6 9 12 15 0 3 6 12 14 16 9 12 15] (vec (ct/to-double-array centers)))
+  actual: (not (m/equals [0 3 6 9 12 15 0 3 6 12 14 16 9 12 15] [4.20108280957632E14 3.0 6.0 9.0 12.0 15.0 4.20108280957632E14 3.0 6.0 12.0 14.0 16.0 9.0 12.0 15.0]))
+  to-double-end
+  freeing derived tensor of address: 140036096288064
+  freeing root tensor of shape [5] : 140036096457344
+
+Ran 1 tests containing 5 assertions.
+2 failures, 0 errors.
+Tests failed.

--- a/project.clj
+++ b/project.clj
@@ -1,15 +1,15 @@
-(defproject tvm-clj "2.3-SNAPSHOT"
+(defproject tvm-clj "3.0-SNAPSHOT"
   :description "Clojure bindings and exploration of the tvm library"
   :url "http://github.com/tech-ascent/tvm-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [techascent/tech.compute "1.16"]
+                 [techascent/tech.compute "2.1"]
                  [potemkin "0.4.4"]]
 
   :profiles {:dev
              ;;Unit tests need this.
-             {:dependencies [[techascent/tech.opencv "1.8"]]}}
+             {:dependencies [[techascent/tech.opencv "2.1"]]}}
 
   :java-source-paths ["java"]
   :native-path "java/native"

--- a/project.clj
+++ b/project.clj
@@ -4,12 +4,12 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [techascent/tech.compute "2.1"]
+                 [techascent/tech.compute "2.2"]
                  [potemkin "0.4.4"]]
 
   :profiles {:dev
              ;;Unit tests need this.
-             {:dependencies [[techascent/tech.opencv "2.1"]]}}
+             {:dependencies [[techascent/tech.opencv "2.2"]]}}
 
   :java-source-paths ["java"]
   :native-path "java/native"

--- a/src/tech/compute/tvm/cpu.clj
+++ b/src/tech/compute/tvm/cpu.clj
@@ -120,6 +120,8 @@
     (cpu-devices))
   (allocate-host-buffer [driver elem-count elem-type options]
     (make-cpu-device-buffer elem-type elem-count))
+  (acceptable-host-buffer? [driver buffer]
+    (tvm-driver/acceptable-tvm-host-buffer? buffer))
 
   tvm-driver/PTVMDriver
   (device-id->device [driver dev-id]

--- a/src/tech/compute/tvm/cpu.clj
+++ b/src/tech/compute/tvm/cpu.clj
@@ -13,7 +13,8 @@
             [tech.compute.tvm :as tvm]
             [tech.compute.registry :as registry]
             [tech.compute :as compute]
-            [tech.datatype.jna :as dtype-jna])
+            [tech.datatype.jna :as dtype-jna]
+            [tech.jna :as jna])
   ;;Setup so these objects (and anything derived from them)
   ;;auto-link to the tvm cpu compute device.
   (:import [org.bytedeco.javacpp.Pointer]
@@ -43,9 +44,6 @@
     (drv/sync-with-host stream))
   (sync-with-stream [_ dst-stream]
     (drv/sync-with-stream stream (:stream dst-stream)))
-
-  resource/PResource
-  (release-resource [_] )
 
   tvm-driver/PTVMStream
   (call-function [_ fn arg-list]
@@ -185,7 +183,7 @@
      {:device-id (fn [item#] 0)}
      tvm-proto/PByteOffset
      {:byte-offset (fn [item#] 0)
-      :base-ptr (fn [item#] (dtype-jna/->ptr-backing-store item#))}))
+      :base-ptr (fn [item#] (jna/->ptr-backing-store item#))}))
 
 
 (extend-tvm-bindings com.sun.jna.Pointer)

--- a/src/tech/compute/tvm/driver.clj
+++ b/src/tech/compute/tvm/driver.clj
@@ -35,3 +35,10 @@ Centralized registring of drivers allowing a symbolic name->driver table."
                 tvm-proto/PByteOffset
                 tvm-proto/PTVMDeviceType
                 tvm-proto/PTVMDeviceId])))
+
+
+(defn acceptable-tvm-host-buffer?
+  "Things that pass this will work in copy-host->device."
+  [item]
+  (and (acceptable-tvm-device-buffer? item)
+       (= :cpu (tvm-proto/device-type item))))

--- a/src/tech/compute/tvm/gpu.clj
+++ b/src/tech/compute/tvm/gpu.clj
@@ -163,6 +163,8 @@
     (enumerate-devices driver))
   (allocate-host-buffer [driver elem-count elem-type options]
     (tvm/make-cpu-device-buffer elem-type elem-count))
+  (acceptable-host-buffer? [driver buffer]
+    (tvm-driver/acceptable-tvm-host-buffer? buffer))
 
   tvm-driver/PTVMDriver
   (device-id->device [driver dev-id]

--- a/src/tech/compute/tvm/gpu.clj
+++ b/src/tech/compute/tvm/gpu.clj
@@ -99,7 +99,9 @@
       (or (= src-device-type dst-device-type)
           (= :cpu dst-device-type))))
   (acceptable-device-buffer? [device item]
-    (tvm-driver/acceptable-tvm-device-buffer? item))
+    (and (tvm-driver/acceptable-tvm-device-buffer? item)
+         (= (bindings/device-type device)
+            (bindings/device-type item))))
 
   drv/PDriverProvider
   (get-driver [dev] driver)

--- a/src/tech/compute/tvm/gpu.clj
+++ b/src/tech/compute/tvm/gpu.clj
@@ -10,7 +10,8 @@
             [tech.compute.tvm.device-buffer :as dbuf]
             [tech.compute.tvm :as tvm]
             [tech.resource :as resource]
-            [tech.datatype.jna :as dtype-jna])
+            [tech.datatype.jna :as dtype-jna]
+            [tech.jna :as jna])
   (:import [com.sun.jna Pointer]))
 
 
@@ -56,7 +57,7 @@
   tvm-driver/PTVMStream
   (call-function [_ fn arg-list]
     (let [stream-ptr (-> (bindings/->tvm stream)
-                         (dtype-jna/->ptr-backing-store))]
+                         (jna/->ptr-backing-store))]
       (when-not (= 0 (Pointer/nativeValue stream-ptr))
         (bindings/set-current-thread-stream stream)))
     (apply fn arg-list))

--- a/src/tvm_clj/jna/base.clj
+++ b/src/tvm_clj/jna/base.clj
@@ -89,7 +89,7 @@ Argpair is of type [symbol type-coersion]."
   (if (instance? Pointer item)
     item
     (-> (dtype-jna/make-typed-pointer :int64 item)
-        dtype-jna/->ptr-backing-store)))
+        jna/->ptr-backing-store)))
 
 
 (defn device-type->int

--- a/src/tvm_clj/jna/dl_tensor.clj
+++ b/src/tvm_clj/jna/dl_tensor.clj
@@ -20,12 +20,15 @@
             [tech.datatype.base :as dtype-base]
             [tech.datatype.java-primitive :as primitive]
             [clojure.core.matrix.protocols :as mp]
-            [tech.datatype :as dtype]
-            )
+            [tech.datatype :as dtype])
+
   (:import [com.sun.jna Native NativeLibrary Pointer Function Platform]
            [com.sun.jna.ptr PointerByReference IntByReference LongByReference]
            [tvm_clj.tvm DLPack$DLContext DLPack$DLTensor DLPack$DLDataType
             DLPack$DLManagedTensor]))
+
+
+(def ^:dynamic *debug-dl-tensor-lifespan* false)
 
 
 (defn ensure-array
@@ -184,9 +187,15 @@
                     (.code dl-dtype) (.bits dl-dtype) (.lanes dl-dtype)
                     device-type device-id
                     retval-ptr))
-    (-> (DLPack$DLTensor. (.getValue retval-ptr))
-        ;;We allow the gc to help us clean up these things.
-        (gc-resource/track #(TVMArrayFree (.getValue retval-ptr))))))
+    (let [retval (DLPack$DLTensor. (.getValue retval-ptr))
+          address (Pointer/nativeValue (.data retval))]
+      (when *debug-dl-tensor-lifespan*
+        (println "allocated root tensor of shape" shape ":" address))
+      ;;We allow the gc to help us clean up these things.
+      (gc-resource/track retval #(do
+                                   (when *debug-dl-tensor-lifespan*
+                                     (println "freeing root tensor of shape" shape ":" address))
+                                   (TVMArrayFree (.getValue retval-ptr)))))))
 
 
 (defn ensure-tensor
@@ -250,21 +259,29 @@
 (defn pointer->tvm-ary
   "Not all backends in TVM can offset their pointer types.  For this reason, tvm arrays
   have a byte_offset member that you can use to make an array not start at the pointer's
-  base address."
+  base address.  If provided this new object will keep the gc-root alive in the eyes
+  of the gc."
   ^DLPack$DLTensor [ptr device-type device-id
                     datatype shape strides
-                    byte-offset]
+                    byte-offset & [gc-root]]
+  ;;Allocate child pointers untracked.  We have to manually track them because on the
+  ;;actual dl-tensor object, they are stored in separate structures that only share the
+  ;;long address.  Thus the GC, after this method, believes that the shape-ptr and
+  ;;strides-ptr objects are free to be cleaned up.
   (let [shape-ptr (dtype-jna/make-typed-pointer
-                   :int64 shape)
+                   :int64 shape {:untracked? true})
         strides-ptr (when strides
                       (dtype-jna/make-typed-pointer
-                       :int64 strides))
+                       :int64 strides {:untracked? true}))
         datatype (or datatype (dtype/get-datatype ptr))
         ;;Get the real pointer
         address (-> (jna/->ptr-backing-store ptr)
                     dtype-jna/pointer->address)
         retval (DLPack$DLTensor.)
-        ctx (DLPack$DLContext.)]
+        ctx (DLPack$DLContext.)
+        gc-root-options {:gc-root gc-root}]
+    (when *debug-dl-tensor-lifespan*
+      (println "deriving from root of shape" shape ":" address))
     (when-not (> address 0)
       (throw (ex-info "Failed to get pointer for buffer."
                       {:original-ptr ptr})))
@@ -278,4 +295,22 @@
     (when strides-ptr
       (set! (.strides retval) (jna/->ptr-backing-store strides-ptr)))
     (set! (.byte_offset retval) (long byte-offset))
-    retval))
+
+    ;;Attach any free calls to the dl-tensor object itself.  Not to its data members.
+    (gc-resource/track
+     retval
+     #(do
+        ;;This is important to establish a valid chain of scopes for the gc system
+        ;;between whatever is providing the ptr data *and* the derived tensor
+        (when *debug-dl-tensor-lifespan*
+          (println "freeing derived tensor of shape" shape ":"
+                   (-> (jna/->ptr-backing-store ptr)
+                       dtype-jna/pointer->address)))
+        ;;Call into the gc root object with a general protocol so it is rooted in this
+        ;;closure.  Then throw it away.
+        (get gc-root-options :gc-root)
+        (-> (jna/->ptr-backing-store shape-ptr)
+            dtype-jna/unsafe-free-ptr)
+        (when strides-ptr
+          (-> (jna/->ptr-backing-store strides-ptr)
+              dtype-jna/unsafe-free-ptr))))))

--- a/src/tvm_clj/jna/node.clj
+++ b/src/tvm_clj/jna/node.clj
@@ -15,7 +15,7 @@
             [tvm-clj.bindings.protocols :as bindings-proto]
             [potemkin :as p]
             [tech.jna :refer [checknil] :as jna]
-            [tech.resource :as resource])
+            [tech.gc-resource :as gc-resource])
   (:import [com.sun.jna Native NativeLibrary Pointer Function Platform]
            [com.sun.jna.ptr PointerByReference IntByReference LongByReference]))
 
@@ -165,10 +165,7 @@
   (->tvm [item]
     item)
   bindings-proto/PConvertToNode
-  (->node [item] item)
-  resource/PResource
-  (release-resource [item]
-    (TVMNodeFree (:tvm-jcpp-handle item))))
+  (->node [item] item))
 
 
 (make-tvm-jna-fn TVMNodeGetTypeIndex
@@ -243,7 +240,7 @@ explicitly; it is done for you."
 (defmethod tvm-value->jvm :node-handle
   [long-val val-type-kwd]
   (-> (construct-node (Pointer. long-val))
-      resource/track))
+      (gc-resource/track #(TVMNodeFree (Pointer. long-val)))))
 
 
 (defn get-node-type

--- a/src/tvm_clj/tvm_jna.clj
+++ b/src/tvm_clj/tvm_jna.clj
@@ -5,7 +5,6 @@
             [tech.datatype.base :as dtype-base]
             [tech.datatype.java-primitive :as primitive]
             [clojure.core.matrix.protocols :as mp]
-            [tech.resource :as resource]
             [tech.jna :refer [checknil] :as jna]
             ;;Standard paths for the tvm library
             [tvm-clj.jna.library-paths :as jna-lib-paths]

--- a/src/tvm_clj/tvm_jna.clj
+++ b/src/tvm_clj/tvm_jna.clj
@@ -133,10 +133,10 @@ Not all backends in TVM can offset their pointer types.  For this reason, tvm ar
   base address."
   [ptr device-type device-id
    datatype shape strides
-   byte-offset]
+   byte-offset & [gc-root]]
   (dl-tensor/pointer->tvm-ary ptr device-type device-id
                               datatype shape strides
-                              byte-offset))
+                              byte-offset gc-root))
 
 (defn call-function
   [tvm-fn & args]

--- a/test/tech/compute/tvm/tensor_test.clj
+++ b/test/tech/compute/tvm/tensor_test.clj
@@ -22,7 +22,7 @@
   (vt/assign-constant! (tvm/driver :cpu) *datatype*))
 
 (def-opencl-dtype-test assign-constant-opencl!
-  (vt/assign-constant! (tvm/driver :opencl) *datatype*))
+  (vt/assign-constant! (tvm/driver :opencl) :float32))
 
 (def-all-dtype-test assign-cpu!
   (vt/assign-marshal (tvm/driver :cpu) *datatype*))


### PR DESCRIPTION
This was a large upgrade.  It contains some 

* performance upgrades in the base datatype libraries
* a move towards using system-blas in tech.compute
* an upgrade in tech.resource that allows us to gc-root resourceable-things.

If you are keeping score, that last point is a very important one.